### PR TITLE
Feature/rollback

### DIFF
--- a/kuka_sunrise_control/robot_control/src/robot_control/rate_scaled_controller.cpp
+++ b/kuka_sunrise_control/robot_control/src/robot_control/rate_scaled_controller.cpp
@@ -33,29 +33,6 @@ RateScaledJointController::RateScaledJointController(
       false, false}, [this](const double & ref_rate) {
       return this->OnReferenceRateChangeRequest(ref_rate);
     });
-/*
-  auto set_rate_callback = [this](
-    kuka_sunrise_interfaces::srv::SetDouble::Request::SharedPtr request,
-    kuka_sunrise_interfaces::srv::SetDouble::Response::SharedPtr response) {
-      int cmd_per_frame = static_cast<int>(JointControllerBase::ms_in_sec_ /
-        loopPeriod() / (8 * request->data)) + 1;
-      if (cmd_per_frame > 2) {
-        cmd_per_frame_temp_ = cmd_per_frame;
-        RCLCPP_INFO(
-          get_logger(),
-          "Successfully changed rate, receiving commands in every %i. frame",
-          cmd_per_frame);
-        response->success = true;
-      } else {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Control loop frequency should be bigger than command receive frequency");
-        response->success = false;
-      }
-    };
-
-  set_rate_service_ = this->create_service<kuka_sunrise_interfaces::srv::SetDouble>(
-    "joint_controller/set_rate", set_rate_callback);*/
 }
 
 void RateScaledJointController::setJointCommandPosition(

--- a/kuka_sunrise_control/teleop_guided_robot/CMakeLists.txt
+++ b/kuka_sunrise_control/teleop_guided_robot/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(kuka_sunrise REQUIRED)
+find_package(kuka_sunrise_interfaces REQUIRED)
 
 include_directories(include)
 
@@ -33,7 +34,7 @@ ament_target_dependencies(keyboard_control rclcpp rclcpp_lifecycle sensor_msgs g
 
 add_executable(system_manager
   src/control_system/system_manager.cpp)
-ament_target_dependencies(system_manager rclcpp rclcpp_lifecycle std_msgs std_srvs)
+ament_target_dependencies(system_manager rclcpp rclcpp_lifecycle std_msgs std_srvs kuka_sunrise_interfaces)
 target_link_libraries(system_manager kuka_sunrise::internal)
 
 install(TARGETS keyboard_control system_manager

--- a/kuka_sunrise_control/teleop_guided_robot/CMakeLists.txt
+++ b/kuka_sunrise_control/teleop_guided_robot/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(kuka_sunrise REQUIRED)
 find_package(kuka_sunrise_interfaces REQUIRED)
+find_package(kroshu_ros2_core REQUIRED)
 
 include_directories(include)
 
@@ -34,7 +35,7 @@ ament_target_dependencies(keyboard_control rclcpp rclcpp_lifecycle sensor_msgs g
 
 add_executable(system_manager
   src/control_system/system_manager.cpp)
-ament_target_dependencies(system_manager rclcpp rclcpp_lifecycle std_msgs std_srvs kuka_sunrise_interfaces)
+ament_target_dependencies(system_manager rclcpp rclcpp_lifecycle std_msgs std_srvs kuka_sunrise_interfaces kroshu_ros2_core)
 target_link_libraries(system_manager kuka_sunrise::internal)
 
 install(TARGETS keyboard_control system_manager

--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -78,8 +78,9 @@ private:
   rclcpp::QoS qos_ = rclcpp::QoS(rclcpp::KeepLast(10));
 
   const std::string JOINT_CONTROLLER = "joint_controller";
-  const std::string CONTROL_LOGIC = "keyboard_control";
   const std::string ROBOT_INTERFACE = "robot_manager";
+  const std::string CONTROL_LOGIC = "keyboard_control";
+  bool control_logic_;
 };
 }  // namespace control_system
 

--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -30,11 +30,11 @@
 #include "kuka_sunrise_interfaces/srv/get_state.hpp"
 #include "kuka_sunrise/internal/service_tools.hpp"
 
+#include "kroshu_ros2_core/ROS2BaseLCNode.hpp"
+
 namespace control_system
 {
-
-// TODO(kovacsge11) maybe derive from ROS2BaseNode
-class SystemManager : public rclcpp_lifecycle::LifecycleNode
+class SystemManager : public kroshu_ros2_core::ROS2BaseLCNode
 {
 public:
   SystemManager(const std::string & node_name, const rclcpp::NodeOptions & options);
@@ -52,8 +52,6 @@ public:
   on_activate(const rclcpp_lifecycle::State &) final;
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State &) final;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_error(const rclcpp_lifecycle::State &) final;
 
 private:
   bool changeState(const std::string & node_name, std::uint8_t transition);
@@ -78,13 +76,6 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr trigger_change_service_;
   rclcpp::CallbackGroup::SharedPtr cbg_;
   rclcpp::QoS qos_ = rclcpp::QoS(rclcpp::KeepLast(10));
-
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SUCCESS =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ERROR =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn FAILURE =
-    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
 
   const std::string JOINT_CONTROLLER = "joint_controller";
   const std::string CONTROL_LOGIC = "keyboard_control";

--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -22,6 +22,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/set_bool.hpp"
@@ -58,12 +59,15 @@ private:
   bool changeRobotCommandingState(bool is_active);
   void robotCommandingStateChanged(bool is_active);
   void getFRIState();
+  lifecycle_msgs::msg::State getState(
+    const std::string & node_name);
   void monitoringLoop();
   bool robot_control_active_ = false;
   bool stop_ = false;
   int lbr_state_ = 0;
   const std::chrono::milliseconds sleeping_time_ms_ = std::chrono::milliseconds(
     200);
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
 
   std::thread polling_thread_;
 

--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -15,7 +15,6 @@
 #ifndef CONTROL_SYSTEM__SYSTEM_MANAGER_HPP_
 #define CONTROL_SYSTEM__SYSTEM_MANAGER_HPP_
 
-#include <vector>
 #include <memory>
 #include <string>
 

--- a/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
+++ b/kuka_sunrise_control/teleop_guided_robot/include/control_system/system_manager.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #ifndef CONTROL_SYSTEM__SYSTEM_MANAGER_HPP_
 #define CONTROL_SYSTEM__SYSTEM_MANAGER_HPP_
 
-#include <string>
 #include <vector>
+#include <memory>
+#include <string>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -25,10 +25,15 @@
 #include "lifecycle_msgs/msg/state.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/set_bool.hpp"
+#include "std_srvs/srv/trigger.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "kuka_sunrise_interfaces/srv/get_state.hpp"
+#include "kuka_sunrise/internal/service_tools.hpp"
 
-namespace teleop_guided_robot
+namespace control_system
 {
 
+// TODO(kovacsge11) maybe derive from ROS2BaseNode
 class SystemManager : public rclcpp_lifecycle::LifecycleNode
 {
 public:
@@ -38,35 +43,41 @@ public:
   void deactivateControl();
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State &);
-
+  on_configure(const rclcpp_lifecycle::State &) final;
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_cleanup(const rclcpp_lifecycle::State &);
-
+  on_cleanup(const rclcpp_lifecycle::State &) final;
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_shutdown(const rclcpp_lifecycle::State &);
-
+  on_shutdown(const rclcpp_lifecycle::State &) final;
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_activate(const rclcpp_lifecycle::State &);
-
+  on_activate(const rclcpp_lifecycle::State &) final;
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_deactivate(const rclcpp_lifecycle::State &);
-
+  on_deactivate(const rclcpp_lifecycle::State &) final;
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_error(const rclcpp_lifecycle::State &);
+  on_error(const rclcpp_lifecycle::State &) final;
 
 private:
   bool changeState(const std::string & node_name, std::uint8_t transition);
   bool changeRobotCommandingState(bool is_active);
   void robotCommandingStateChanged(bool is_active);
-  std::vector<rclcpp::Subscription<lifecycle_msgs::msg::Transition>::SharedPtr>
-  lifecycle_subscriptions_;
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr robot_commanding_state_subscription_;
-  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr change_robot_commanding_state_client_;
-  bool robot_control_active_;
+  void getFRIState();
+  void monitoringLoop();
+  bool robot_control_active_ = false;
+  bool stop_ = false;
+  int lbr_state_ = 0;
+  const std::chrono::milliseconds sleeping_time_ms_ = std::chrono::milliseconds(
+    200);
 
-  rclcpp::QoS qos_;
-  rclcpp::callback_group::CallbackGroup::SharedPtr cbg_;
+  std::thread polling_thread_;
+
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::JointState>::SharedPtr
+    reference_joint_state_publisher_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr robot_commanding_state_subscription_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr manage_processing_publisher_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr change_robot_manager_state_client_;
+  rclcpp::Client<kuka_sunrise_interfaces::srv::GetState>::SharedPtr get_state_client_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr trigger_change_service_;
+  rclcpp::CallbackGroup::SharedPtr cbg_;
+  rclcpp::QoS qos_ = rclcpp::QoS(rclcpp::KeepLast(10));
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SUCCESS =
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -79,8 +90,6 @@ private:
   const std::string CONTROL_LOGIC = "keyboard_control";
   const std::string ROBOT_INTERFACE = "robot_manager";
 };
-
-
-}  // namespace teleop_guided_robot
+}  // namespace control_system
 
 #endif  // CONTROL_SYSTEM__SYSTEM_MANAGER_HPP_

--- a/kuka_sunrise_control/teleop_guided_robot/launch/kinect_driver_arm_tracking.py
+++ b/kuka_sunrise_control/teleop_guided_robot/launch/kinect_driver_arm_tracking.py
@@ -1,0 +1,76 @@
+# Copyright 2020 Zoltán Rési
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+
+from launch.actions.include_launch_description import IncludeLaunchDescription
+from launch.launch_description_sources.python_launch_description_source import PythonLaunchDescriptionSource  # noqa: E501
+import launch_ros.actions
+import yaml
+
+
+def load_file(package_name, file_path):
+
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return file.read()
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        print('Couldnt load file ' + absolute_file_path)
+        return None
+
+
+def load_yaml(package_name, file_path):
+
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return yaml.safe_load(file)
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        print('Couldnt load yaml ' + absolute_file_path)
+        return None
+
+
+def generate_launch_description():
+
+    kuka_sunrise_dir = get_package_share_directory('kuka_sunrise')
+
+    kuka_sunrise_interface = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([kuka_sunrise_dir, '/launch/kuka_sunrise.launch.py'])
+        )
+
+    joint_controller = launch_ros.actions.LifecycleNode(
+        package='robot_control', executable='rate_scaled_controller', output='both',
+        arguments=['--ros-args', '--log-level', 'info'], parameters=[{'reference_rate': 12.0}],
+        name='joint_controller', remappings=[('measured_joint_state', 'lbr_joint_state'),
+                                             ('joint_command', 'lbr_joint_command')]
+        )
+
+    system_manager = launch_ros.actions.LifecycleNode(
+        package='teleop_guided_robot', executable='system_manager', output='screen',
+        name='system_manager'
+        )
+
+    return LaunchDescription([
+        kuka_sunrise_interface,
+        system_manager,
+        joint_controller
+        ])

--- a/kuka_sunrise_control/teleop_guided_robot/package.xml
+++ b/kuka_sunrise_control/teleop_guided_robot/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>teleop_guided_robot</name>
   <version>0.0.0</version>
-  <description>Package for managing the connection between ROS and KUKA Sunrise FRI</description>
+  <description>Package for starting keyboard-controlled motion and synchronising the necessary nodes</description>
   <maintainer email="resizoltan@gmail.com">rosdeveloper</maintainer>
   <license>Apache 2.0</license>
 

--- a/kuka_sunrise_control/teleop_guided_robot/package.xml
+++ b/kuka_sunrise_control/teleop_guided_robot/package.xml
@@ -17,6 +17,7 @@
   <depend>std_srvs</depend>
   <depend>kuka_sunrise_interfaces</depend>
   <depend>kuka_sunrise</depend>
+  <depend>kroshu_ros2_core</depend>
   
   <exec_depend>robot_control</exec_depend>
   <exec_depend>pluginlib</exec_depend>

--- a/kuka_sunrise_control/teleop_guided_robot/package.xml
+++ b/kuka_sunrise_control/teleop_guided_robot/package.xml
@@ -3,30 +3,23 @@
 <package format="3">
   <name>teleop_guided_robot</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>Package for managing the connection between ROS and KUKA Sunrise FRI</description>
   <maintainer email="resizoltan@gmail.com">rosdeveloper</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
-  <build_depend>kuka_sunrise</build_depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>kuka_sunrise_interfaces</depend>
+  <depend>kuka_sunrise</depend>
   
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
-  
-  <exec_depend>kuka_sunrise</exec_depend>
   <exec_depend>robot_control</exec_depend>
-  <exec_depend>key_teleop</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -298,9 +298,7 @@ lifecycle_msgs::msg::State SystemManager::getState(
     client, request, 2000, 1000);
 
   if (!response) {
-    RCLCPP_ERROR(
-      get_logger(), "Future status not ready, could not get state of %s",
-      node_name.c_str());
+    RCLCPP_ERROR(get_logger(), "Could not get state of %s", node_name.c_str());
     return lifecycle_msgs::msg::State();
   }
   return response->current_state;
@@ -350,7 +348,7 @@ bool SystemManager::changeRobotCommandingState(bool is_active)
   auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
   request->data = is_active;
 
-  auto response = kuka_sunrise::sendRequest<lifecycle_msgs::srv::GetState::Response>(
+  auto response = kuka_sunrise::sendRequest<std_srvs::srv::SetBool::Response>(
     change_robot_manager_state_client_, request, 2000, 1000);
 
   if (!response || !response->success) {

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -194,7 +194,7 @@ on_deactivate(
   const rclcpp_lifecycle::State &)
 {
   if (robot_control_active_ && !changeRobotCommandingState(false)) {
-    return FAILURE;
+    return ERROR;
   }
   robot_control_active_ = false;
   if (polling_thread_.joinable()) {polling_thread_.join();}
@@ -202,19 +202,19 @@ on_deactivate(
       ROBOT_INTERFACE,
       lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
   {
-    return FAILURE;
+    return ERROR;
   }
   if (!changeState(
       JOINT_CONTROLLER,
       lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
   {
-    return FAILURE;
+    return ERROR;
   }
 
   if (control_logic_ &&
     !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
   {
-    return FAILURE;
+    return ERROR;
   }
 
   return SUCCESS;

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -278,9 +278,9 @@ bool SystemManager::changeState(
   request->transition.id = transition;
 
   auto response = kuka_sunrise::sendRequest<lifecycle_msgs::srv::ChangeState::Response>(
-    client, request, 2000, 1000);
+    client, request, 2000, 3000);
 
-  if (!response || response->success) {
+  if (!response || !response->success) {
     RCLCPP_ERROR(get_logger(), "Could not change state of %s", node_name.c_str());
     return false;
   }

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -107,7 +107,9 @@ on_configure(
     return ERROR;
   }
 
-  if (control_logic_ && !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)) {
+  if (control_logic_ &&
+    !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+  {
     return FAILURE;
   }
   return SUCCESS;
@@ -129,7 +131,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn System
   {
     return FAILURE;
   }
-  if (control_logic_ && !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)) {
+  if (control_logic_ &&
+    !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP))
+  {
     return FAILURE;
   }
 
@@ -171,7 +175,9 @@ SystemManager::on_activate(const rclcpp_lifecycle::State &)
     }
     return FAILURE;
   }
-  if (control_logic_ && !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE)) {
+  if (control_logic_ &&
+    !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+  {
     return FAILURE;
   }
 
@@ -205,7 +211,9 @@ on_deactivate(
     return FAILURE;
   }
 
-  if (control_logic_ && !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE)) {
+  if (control_logic_ &&
+    !changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
+  {
     return FAILURE;
   }
 

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -24,7 +24,7 @@ namespace control_system
 SystemManager::SystemManager(
   const std::string & node_name,
   const rclcpp::NodeOptions & options)
-: LifecycleNode(node_name, options)
+: ROS2BaseLCNode(node_name, options)
 {
   qos_.reliable();
   cbg_ = this->create_callback_group(
@@ -242,13 +242,6 @@ SystemManager::on_shutdown(const rclcpp_lifecycle::State & state)
 
 
   return result;
-}
-
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SystemManager::on_error(
-  const rclcpp_lifecycle::State &)
-{
-  RCLCPP_INFO(get_logger(), "An error occured");
-  return SUCCESS;
 }
 
 void SystemManager::monitoringLoop()

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -14,107 +14,196 @@
 
 #include <string>
 #include <memory>
+#include <thread>
 
 #include "control_system/system_manager.hpp"
-#include "kuka_sunrise/internal/service_tools.hpp"
 
-namespace teleop_guided_robot
+namespace control_system
 {
 
-SystemManager::SystemManager(const std::string & node_name, const rclcpp::NodeOptions & options)
-: LifecycleNode(node_name, options), robot_control_active_(false), qos_(rclcpp::KeepLast(10))
+SystemManager::SystemManager(
+  const std::string & node_name,
+  const rclcpp::NodeOptions & options)
+: LifecycleNode(node_name, options)
 {
   qos_.reliable();
-  cbg_ = this->create_callback_group(rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
-  change_robot_commanding_state_client_ = this->create_client<std_srvs::srv::SetBool>(
-    ROBOT_INTERFACE + "/set_commanding_state", qos_.get_rmw_qos_profile(), cbg_);
-  robot_commanding_state_subscription_ = this->create_subscription<std_msgs::msg::Bool>(
-    ROBOT_INTERFACE + "/commanding_state_changed", qos_, [this](std_msgs::msg::Bool::SharedPtr msg)
-    {
+  cbg_ = this->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+  change_robot_manager_state_client_ = this->create_client<
+    std_srvs::srv::SetBool>(
+    ROBOT_INTERFACE + "/set_commanding_state",
+    qos_.get_rmw_qos_profile(), cbg_);
+  robot_commanding_state_subscription_ = this->create_subscription<
+    std_msgs::msg::Bool>(
+    ROBOT_INTERFACE + "/commanding_state_changed", qos_,
+    [this](std_msgs::msg::Bool::SharedPtr msg) {
       this->robotCommandingStateChanged(msg->data);
     });
+
+  get_state_client_ =
+    this->create_client<kuka_sunrise_interfaces::srv::GetState>(
+    "robot_control/get_fri_state");
+  manage_processing_publisher_ = this->create_publisher<std_msgs::msg::Bool>(
+    "system_manager/manage", 1);
+  manage_processing_publisher_->on_activate();
+  auto trigger_change_callback = [this](
+    std_srvs::srv::Trigger::Request::SharedPtr,
+    std_srvs::srv::Trigger::Response::SharedPtr response) {
+      response->success = true;
+
+      if (this->get_current_state().label() == "active") {
+        std_msgs::msg::Bool activate;
+        activate.data = false;
+        manage_processing_publisher_->publish(activate);
+        if (this->deactivate().label() != "inactive") {
+          response->success = false;
+        }
+        RCLCPP_WARN(
+          get_logger(),
+          "Motion stopped externally, deactivating controls and managers");
+      } else {
+        RCLCPP_WARN(
+          get_logger(),
+          "Invalid request, system manager not active");
+      }
+    };
+  trigger_change_service_ = this->create_service<std_srvs::srv::Trigger>(
+    "system_manager/trigger_change", trigger_change_callback);
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SystemManager::
 on_configure(
-  const rclcpp_lifecycle::State & state)
+  const rclcpp_lifecycle::State &)
 {
-  (void)state;
-  if (!changeState(ROBOT_INTERFACE, lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)) {
+  if (!changeState(
+      ROBOT_INTERFACE,
+      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+  {
     return FAILURE;
   }
-  if (!changeState(JOINT_CONTROLLER, lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)) {
+  if (!changeState(
+      JOINT_CONTROLLER,
+      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE))
+  {
+    if (!changeState(
+        ROBOT_INTERFACE,
+        lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP))
+    {
+      RCLCPP_ERROR(get_logger(), "Could not solve differing states, restart needed");
+    }
     return ERROR;
   }
+
   if (!changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)) {
-    return ERROR;
+    return FAILURE;
   }
   return SUCCESS;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SystemManager::on_cleanup(
-  const rclcpp_lifecycle::State & state)
+  const rclcpp_lifecycle::State &)
 {
-  (void)state;
-  if (!changeState(ROBOT_INTERFACE, lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)) {
+  if (!changeState(
+      ROBOT_INTERFACE,
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP))
+  {
+    return FAILURE;
+  }
+
+  if (!changeState(
+      JOINT_CONTROLLER,
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP))
+  {
     return FAILURE;
   }
   if (!changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)) {
-    return ERROR;
+    return FAILURE;
   }
-  if (!changeState(JOINT_CONTROLLER, lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)) {
-    return ERROR;
-  }
+
   return SUCCESS;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemManager::on_activate(
-  const rclcpp_lifecycle::State & state)
+SystemManager::on_activate(const rclcpp_lifecycle::State &)
 {
-  (void)state;
-  if (!changeState(ROBOT_INTERFACE, lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE)) {
+  if (!changeState(
+      ROBOT_INTERFACE,
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+  {
     return FAILURE;
   }
-  if (!changeState(JOINT_CONTROLLER, lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE)) {
-    return ERROR;
+  if (!changeState(
+      JOINT_CONTROLLER,
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE))
+  {
+    if (!changeState(
+        ROBOT_INTERFACE,
+        lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
+    {
+      RCLCPP_ERROR(get_logger(), "Could not solve differing states, restart needed");
+      return ERROR;
+    }
+    return FAILURE;
   }
   if (!robot_control_active_ && !changeRobotCommandingState(true)) {
-    return ERROR;
+    if (!changeState(
+        ROBOT_INTERFACE,
+        lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE) ||
+      !changeState(
+        JOINT_CONTROLLER,
+        lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
+    {
+      RCLCPP_ERROR(get_logger(), "Could not solve differing states, restart needed");
+      return ERROR;
+    }
+    return FAILURE;
   }
-  robot_control_active_ = true;
   if (!changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE)) {
-    return ERROR;
+    return FAILURE;
   }
+
+  polling_thread_ = std::thread(&SystemManager::monitoringLoop, this);
+  robot_control_active_ = true;
+  std_msgs::msg::Bool activate;
+  activate.data = true;
+  manage_processing_publisher_->publish(activate);
   return SUCCESS;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SystemManager::
 on_deactivate(
-  const rclcpp_lifecycle::State & state)
+  const rclcpp_lifecycle::State &)
 {
-  (void)state;
+  if (robot_control_active_ && !changeRobotCommandingState(false)) {
+    return FAILURE;
+  }
+  robot_control_active_ = false;
+  if (polling_thread_.joinable()) {polling_thread_.join();}
+  if (!changeState(
+      ROBOT_INTERFACE,
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
+  {
+    return FAILURE;
+  }
+  if (!changeState(
+      JOINT_CONTROLLER,
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE))
+  {
+    return FAILURE;
+  }
+
   if (!changeState(CONTROL_LOGIC, lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE)) {
     return FAILURE;
   }
-  if (robot_control_active_ && !changeRobotCommandingState(false)) {
-    return ERROR;
-  }
-  robot_control_active_ = false;
-  if (!changeState(ROBOT_INTERFACE, lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE)) {
-    return ERROR;
-  }
-  if (!changeState(JOINT_CONTROLLER, lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE)) {
-    return ERROR;
-  }
+
   return SUCCESS;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-SystemManager::on_shutdown(
-  const rclcpp_lifecycle::State & state)
+SystemManager::on_shutdown(const rclcpp_lifecycle::State & state)
 {
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn result = SUCCESS;
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn result =
+    SUCCESS;
   switch (state.id()) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
       result = this->on_deactivate(get_current_state());
@@ -132,39 +221,51 @@ SystemManager::on_shutdown(
       break;
   }
   if (!changeState(
-      CONTROL_LOGIC,
+      ROBOT_INTERFACE,
       lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN))
   {
     return FAILURE;
   }
   if (!changeState(
-      ROBOT_INTERFACE,
-      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN))
-  {
-    return ERROR;
-  }
-  if (!changeState(
       JOINT_CONTROLLER,
       lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN))
   {
-    return ERROR;
+    return FAILURE;
   }
+
+  if (!changeState(
+      CONTROL_LOGIC,
+      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN))
+  {
+    return FAILURE;
+  }
+
+
   return result;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SystemManager::on_error(
-  const rclcpp_lifecycle::State & state)
+  const rclcpp_lifecycle::State &)
 {
-  (void)state;
   RCLCPP_INFO(get_logger(), "An error occured");
   return SUCCESS;
 }
 
-bool SystemManager::changeState(const std::string & node_name, std::uint8_t transition)
+void SystemManager::monitoringLoop()
+{
+  while (this->get_current_state().label() == "active") {
+    getFRIState();
+    std::this_thread::sleep_for(sleeping_time_ms_);
+  }
+  RCLCPP_WARN(get_logger(), "Stopping monitoring loop");
+}
+
+bool SystemManager::changeState(
+  const std::string & node_name,
+  std::uint8_t transition)
 {
   auto client = this->create_client<lifecycle_msgs::srv::ChangeState>(
-    node_name + "/change_state",
-    qos_.get_rmw_qos_profile(), cbg_);
+    node_name + "/change_state", qos_.get_rmw_qos_profile(), cbg_);
   auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
   request->transition.id = transition;
   if (!client->wait_for_service(std::chrono::milliseconds(2000))) {
@@ -172,40 +273,86 @@ bool SystemManager::changeState(const std::string & node_name, std::uint8_t tran
     return false;
   }
   auto future_result = client->async_send_request(request);
-  auto future_status =
-    kuka_sunrise::wait_for_result(future_result, std::chrono::milliseconds(3000));
+  auto future_status = kuka_sunrise::wait_for_result(
+    future_result,
+    std::chrono::milliseconds(3000));
   if (future_status != std::future_status::ready) {
-    RCLCPP_ERROR(get_logger(), "Future status not ready");
+    RCLCPP_ERROR(get_logger(), "Future status not ready, could not change state of " + node_name);
     return false;
   }
   if (future_result.get()->success) {
     return true;
   } else {
-    RCLCPP_ERROR(get_logger(), "Future result not success");
+    RCLCPP_ERROR(get_logger(), "Future result not success, could not change state of " + node_name);
     return false;
   }
 }
 
+void SystemManager::getFRIState()
+{
+  while (!get_state_client_->wait_for_service(std::chrono::milliseconds(1000))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Interrupted while waiting for the service. Exiting.");
+      return;
+    }
+    RCLCPP_INFO(this->get_logger(), "service not available, waiting again...");
+  }
+  auto request = std::make_shared<
+    kuka_sunrise_interfaces::srv::GetState::Request>();
+
+  auto response_received_callback =
+    [this](
+    rclcpp::Client<kuka_sunrise_interfaces::srv::GetState>::SharedFuture future) {
+      auto result = future.get();
+      lbr_state_ = static_cast<int>(result->data);
+
+      // Two consecutive non-four states are needed for shutdown
+      // to avoid unnecessary stops
+      if (lbr_state_ != 4 && !stop_) {
+        stop_ = true;
+      } else if (lbr_state_ != 4 && stop_) {
+        std_msgs::msg::Bool activate;
+        activate.data = false;
+        manage_processing_publisher_->publish(activate);
+      } else {
+        stop_ = false;
+      }
+      RCLCPP_DEBUG(this->get_logger(), "State: %i", lbr_state_);
+    };
+  auto future_result = get_state_client_->async_send_request(
+    request,
+    response_received_callback);
+}
+
+// Activate the ActivatableInterface of robot_manager_node
 bool SystemManager::changeRobotCommandingState(bool is_active)
 {
   auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
   request->data = is_active;
-  if (!change_robot_commanding_state_client_->wait_for_service(std::chrono::milliseconds(2000))) {
+  if (!change_robot_manager_state_client_->wait_for_service(
+      std::chrono::milliseconds(2000)))
+  {
     RCLCPP_ERROR(get_logger(), "Wait for service failed");
     return false;
   }
-  auto future_result = change_robot_commanding_state_client_->async_send_request(request);
-  auto future_status =
-    kuka_sunrise::wait_for_result(future_result, std::chrono::milliseconds(3000));
+  auto future_result =
+    change_robot_manager_state_client_->async_send_request(request);
+  auto future_status = kuka_sunrise::wait_for_result(
+    future_result,
+    std::chrono::milliseconds(3000));
   if (future_status != std::future_status::ready) {
-    RCLCPP_ERROR(get_logger(), "Future status not ready");
+    RCLCPP_ERROR(get_logger(), "Future status not ready, could not change robot commanding state");
     return false;
   }
   if (future_result.get()->success) {
     robot_control_active_ = true;
     return true;
   } else {
-    RCLCPP_ERROR(get_logger(), "Future result not success");
+    RCLCPP_ERROR(
+      get_logger(),
+      "Future result not success, could not change robot commanding state");
     return false;
   }
 }
@@ -214,22 +361,21 @@ void SystemManager::robotCommandingStateChanged(bool is_active)
 {
   if (is_active == false && this->get_current_state().label() == "active") {
     robot_control_active_ = false;
-    // TODO(resizoltan) check if successful
+    // TODO(resizoltan): check if successful
     this->deactivate();
   }
 }
 
-}  // namespace teleop_guided_robot
+}  // namespace control_system
 
 int main(int argc, char * argv[])
 {
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
   rclcpp::init(argc, argv);
   rclcpp::executors::MultiThreadedExecutor executor;
-  auto node = std::make_shared<teleop_guided_robot::SystemManager>(
-    "system_manager",
-    rclcpp::NodeOptions());
+  auto node = std::make_shared<control_system::SystemManager>(
+    "system_manager", rclcpp::NodeOptions());
   executor.add_node(node->get_node_base_interface());
   executor.spin();
   rclcpp::shutdown();

--- a/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
+++ b/kuka_sunrise_control/teleop_guided_robot/src/control_system/system_manager.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <memory>
 #include <thread>
+#include <vector>
 
 #include "control_system/system_manager.hpp"
 

--- a/kuka_sunrise_driver/include/kuka_sunrise/internal/service_tools.hpp
+++ b/kuka_sunrise_driver/include/kuka_sunrise/internal/service_tools.hpp
@@ -46,13 +46,11 @@ sendRequest(
   ClientT client, RequestT request, const uint32_t & service_timeout_ms = 2000,
   const uint32_t & response_timeout_ms = 100)
 {
-  if (service_timeout_ms) {
-    if (!client->wait_for_service(
-        std::chrono::milliseconds(service_timeout_ms)))
-    {
-      printf("Wait for service failed\n");
-      return nullptr;
-    }
+  if (service_timeout_ms && !client->wait_for_service(
+      std::chrono::milliseconds(service_timeout_ms)))
+  {
+    printf("Wait for service failed\n");
+    return nullptr;
   }
   auto future_result = client->async_send_request(request);
   auto future_status = wait_for_result(

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -214,12 +214,12 @@ RobotManagerNode::on_deactivate(const rclcpp_lifecycle::State &)
 
   if (this->isActive() && !this->deactivate()) {
     RCLCPP_ERROR(get_logger(), "could not deactivate control");
-    return FAILURE;
+    return ERROR;
   }
 
   if (!robot_manager_->endFRI()) {
     RCLCPP_ERROR(get_logger(), "could not end fri");
-    return FAILURE;
+    return ERROR;
   }
 
   if (!requestRobotControlNodeStateTransition(

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -98,7 +98,7 @@ RobotManagerNode::on_configure(const rclcpp_lifecycle::State &)
   auto trigger_request =
     std::make_shared<std_srvs::srv::Trigger::Request>();
 
-  auto response = kuka_sunrise::sendRequest<std_srvs::srv::Trigger::Request>(
+  auto response = kuka_sunrise::sendRequest<std_srvs::srv::Trigger::Response>(
     set_parameter_client_, trigger_request, 0, 1000);
 
   if (!response || !response->success) {
@@ -291,7 +291,7 @@ bool RobotManagerNode::requestRobotControlNodeStateTransition(std::uint8_t trans
   auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
   request->transition.id = transition;
 
-  auto response = kuka_sunrise::sendRequest<lifecycle_msgs::srv::ChangeState::Request>(
+  auto response = kuka_sunrise::sendRequest<lifecycle_msgs::srv::ChangeState::Response>(
     change_robot_control_state_client_, request, 2000, 3000);
 
   if (!response || !response->success) {
@@ -306,7 +306,7 @@ bool RobotManagerNode::setRobotControlNodeCommandState(bool active)
   auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
   request->data = active;
 
-  auto response = kuka_sunrise::sendRequest<std_srvs::srv::SetBool::Request>(
+  auto response = kuka_sunrise::sendRequest<std_srvs::srv::SetBool::Response>(
     set_command_state_client_, request, 0, 1000);
 
   if (!response || !response->success) {

--- a/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
+++ b/kuka_sunrise_driver/src/kuka_sunrise/robot_manager_node.cpp
@@ -97,19 +97,14 @@ RobotManagerNode::on_configure(const rclcpp_lifecycle::State &)
 
   auto trigger_request =
     std::make_shared<std_srvs::srv::Trigger::Request>();
-  auto future_result = set_parameter_client_->async_send_request(trigger_request);
-  auto future_status = kuka_sunrise::wait_for_result(
-    future_result,
-    std::chrono::milliseconds(3000));
-  if (future_status != std::future_status::ready) {
-    RCLCPP_ERROR(get_logger(), "Future status not ready, could not set parameters");
-    return FAILURE;
-  }
-  if (!future_result.get()->success) {
-    RCLCPP_ERROR(get_logger(), "Future result not success, could not set parameters");
-    return FAILURE;
-  }
 
+  auto response = kuka_sunrise::sendRequest<std_srvs::srv::Trigger::Request>(
+    set_parameter_client_, trigger_request, 0, 1000);
+
+  if (!response || !response->success) {
+    RCLCPP_ERROR(get_logger(), "Could not set parameters");
+    return FAILURE;
+  }
   return SUCCESS;
 }
 
@@ -295,22 +290,15 @@ bool RobotManagerNode::requestRobotControlNodeStateTransition(std::uint8_t trans
 {
   auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
   request->transition.id = transition;
-  if (!change_robot_control_state_client_->wait_for_service(std::chrono::milliseconds(2000))) {
-    RCLCPP_ERROR(get_logger(), "Wait for service failed");
+
+  auto response = kuka_sunrise::sendRequest<lifecycle_msgs::srv::ChangeState::Request>(
+    change_robot_control_state_client_, request, 2000, 3000);
+
+  if (!response || !response->success) {
+    RCLCPP_ERROR(get_logger(), "Could not change robot control state");
     return false;
   }
-  auto future_result = change_robot_control_state_client_->async_send_request(request);
-  auto future_status = wait_for_result(future_result, std::chrono::milliseconds(3000));
-  if (future_status != std::future_status::ready) {
-    RCLCPP_ERROR(get_logger(), "Future status not ready, could not change robot control state");
-    return false;
-  }
-  if (future_result.get()->success) {
-    return true;
-  } else {
-    RCLCPP_ERROR(get_logger(), "Future result not success, could not change robot control state");
-    return false;
-  }
+  return true;
 }
 
 bool RobotManagerNode::setRobotControlNodeCommandState(bool active)
@@ -318,18 +306,13 @@ bool RobotManagerNode::setRobotControlNodeCommandState(bool active)
   auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
   request->data = active;
 
-  auto future_result = set_command_state_client_->async_send_request(request);
-  auto future_status = wait_for_result(future_result, std::chrono::milliseconds(3000));
-  if (future_status != std::future_status::ready) {
-    RCLCPP_ERROR(get_logger(), "Future status not ready, could not set robot command state");
+  auto response = kuka_sunrise::sendRequest<std_srvs::srv::SetBool::Request>(
+    set_command_state_client_, request, 0, 1000);
+
+  if (!response || !response->success) {
+    RCLCPP_ERROR(get_logger(), "Could not set robot command state");
     return false;
   }
-
-  if (!future_result.get()->success) {
-    RCLCPP_ERROR(get_logger(), "Future result not success, could not set robot command state");
-    return false;
-  }
-
   return true;
 }
 


### PR DESCRIPTION
Rollback is simplified for configuration and activation of the system_manager
- if one component fails, the cleanup/deactivation callback is called for the system manager
- these are implemented so, that they check the actual state of the components and do the rollback if necessary
- this way the nodes should be always in sync (if the rollback fails, error state is triggered)

Changed sync client requests to new SendRequest<> wrapper
